### PR TITLE
Hide detailed directions from suggested routes landing window and send routes and user input data from frontend to backend

### DIFF
--- a/dublinbus/dublinbus/urls.py
+++ b/dublinbus/dublinbus/urls.py
@@ -24,6 +24,11 @@ urlpatterns = [
     path("realtime/", main_views.real_time, name="realtime"),
     path("busroutes/", main_views.bus_routes, name="busroutes"),
     path("api/get_bus_stops/", main_api.get_bus_stops, name="getbusstops"),
+    path(
+        "api/get_journey_travel_time_estimation/",
+        main_api.get_journey_travel_time_estimation,
+        name="gettraveltimes",
+    ),
     path("admin/", admin.site.urls),
     path("api/weather_widget", main_api.weather_widget, name="weather_widget"),
     path("api/autocomple_route", main_api.autocomple_route, name="autocomple_route"),

--- a/dublinbus/main/api.py
+++ b/dublinbus/main/api.py
@@ -1,6 +1,9 @@
 from django.http import JsonResponse
+from django.http.response import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
 from main.models import Route, Trip, Trips_Stops, Stop
 from main.cache_manipulator import *
+import json
 
 # returns all bus stops for each direction of each bus route
 def get_bus_stops(request):
@@ -69,3 +72,18 @@ def autocomple_route(request):
             routes.append(route_obj["short_name"])
 
     return JsonResponse({"status": 200, "data": routes})
+
+
+# https://docs.djangoproject.com/en/3.2/ref/csrf/#django.views.decorators.csrf.csrf_exempt
+# this decorator is added to exempt this function from CSRF protection, this should be removed later and the problem addressed in another ticket
+# to address the issue later the following should be followed https://docs.djangoproject.com/en/3.2/ref/csrf/#ajax
+@csrf_exempt
+def get_journey_travel_time_estimation(request):
+    # this endpoint receives a dictionary with departure date/time and route's data
+    if request.method == "POST":
+        routesData = json.loads(request.body)
+        # TODO access routes' data and format any data if necessary according to the data format the models were trained on
+        # TODO feed data to models and get estimated travel time
+        # TODO calculate total time, if needed by combining our Dublin Bus predictions with other times from other steps that are not operated by Dublin Bus
+        # TODO send total times for all suggested routes to frontend that will render them by replacing the times injected from the google directions api response
+        return JsonResponse({})

--- a/dublinbus/main/static/journeyplanner.js
+++ b/dublinbus/main/static/journeyplanner.js
@@ -16,6 +16,12 @@ function initMap() {
 let directionsService1;
 let directionsRenderer1;
 
+// variable that will hold the departure date and time the user selected
+let departureTime;
+
+// dict that will have info about departure time and every suggested route by the directions api to send to backend
+let suggestedRoutesData = { departure_time: "", routesData: [] };
+
 function initDirectionsService() {
   directionsService1 = new google.maps.DirectionsService();
 }
@@ -43,12 +49,24 @@ function calculateAndDisplayRoute(directionsService, directionsRenderer) {
       provideRouteAlternatives: true,
     })
     .then((response) => {
+      // check response status here, in case the api fails to give a response we can handle it
+      if (response.status != "OK") {
+        throw new Error("status: " + response.status);
+      }
       directionsRenderer.setDirections(response);
+      // add listener that calls directionsResultDivChanged() every time a new html element is added to the "directions_results" div
+      // we need to catch when the directions steps' div is injected so we can hide it
+      document
+        .getElementById("directions_results")
+        .addEventListener(
+          "DOMSubtreeModified",
+          directionsResultDivChanged,
+          false
+        );
+      getRoutesTravelEstimationsFromModels(response);
       directionsRenderer.setPanel(
         document.getElementById("directions_results")
       );
-
-      console.log(response);
 
       //Switching UI
       const searchUI = document.getElementById("searchUI");
@@ -57,7 +75,23 @@ function calculateAndDisplayRoute(directionsService, directionsRenderer) {
       const resultsUI = document.getElementById("resultsUI");
       resultsUI.style.display = "block";
     })
-    .catch((e) => window.alert("No bus directions could be found"));
+    .catch((e) => {
+      console.log(e);
+      window.alert("No bus directions could be found");
+    });
+}
+
+// hides the directions detailed steps from first window where the multiple routes are suggested
+// we will display the detailed directions when user clicks the "route details" button
+function directionsResultDivChanged() {
+  if (
+    !document.getElementById("directions_results").hasChildNodes() ||
+    document.getElementById("directions_results").childNodes.length != 2
+  ) {
+    return;
+  }
+  document.getElementById("directions_results").children[1].style.display =
+    "none";
 }
 
 //Clear the map
@@ -122,4 +156,126 @@ function setAutocomplete(object, id) {
     fields: ["place_id", "geometry", "name"],
   });
   return object;
+}
+
+// returns travel time estimation for all suggested routes that come in the google directions API
+function getRoutesTravelEstimationsFromModels(directionsResponseObject) {
+  suggestedRoutesData.routesData = getRoutesDataFromDirectionsAPIResponse(
+    directionsResponseObject
+  );
+  // get departure date and time selected by the user
+  departureTime = document.getElementById("departure-time").value;
+  suggestedRoutesData.departure_time = departureTime;
+
+  let travelTimeEstimationsEndpoint =
+    "/api/get_journey_travel_time_estimation/";
+  fetch(travelTimeEstimationsEndpoint, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(suggestedRoutesData),
+  })
+    .then((response) => {
+      if (response.ok) {
+        return response.json();
+      } else {
+        document.getElementById("user-error-message").innerText =
+          "Something went wrong, please try again.";
+        // status and statusText doesn't work for all browsers but works in Chrome and Safari
+        throw new Error(response.status + ", " + response.statusText);
+      }
+    })
+    .then((travelTimeEstimations) => {
+      //travelTimeEstimations will be the response sent by the backend with the travel time estimations for all suggested routes
+    })
+    .catch((error) => {
+      console.log(error);
+    });
+}
+
+// returns an array with routes data relevant to feed the models
+function getRoutesDataFromDirectionsAPIResponse(directionsResponseObject) {
+  if (
+    !directionsResponseObject.routes ||
+    directionsResponseObject.routes.length == 0
+  ) {
+    return;
+  }
+  let routesData = [];
+  // for each suggested route get the steps data for it
+  for (let i = 0; i < directionsResponseObject.routes.length; i++) {
+    suggestedRoute = getRouteData(directionsResponseObject.routes[i]);
+    routesData.push(suggestedRoute);
+  }
+  return routesData;
+}
+
+// returns an array with specific data for every step of a suggested route
+// for every step, if it is not a "Dublin Bus" service we are saving the times that the google directions api provides for that step
+// if the step is a "Dublin Bus" service we store the bus stops, bus name and number, and number of stops
+function getRouteData(route) {
+  if (!route.legs || route.legs.length == 0) {
+    return {};
+  }
+  routeLegs = route.legs[0];
+  if (!routeLegs.steps || routeLegs.steps.length == 0) {
+    return {};
+  }
+  let routeData = [];
+  routeSteps = routeLegs.steps;
+  for (let i = 0; i < routeSteps.length; i++) {
+    let routeStepsData = { step: {} };
+    if (routeSteps[i].travel_mode == "WALKING") {
+      const step_duration = routeSteps[i].duration.text;
+      const travel_mode = "WALKING";
+      routeStepsData.step = {
+        step_duration: step_duration,
+        travel_mode: travel_mode,
+      };
+    }
+    if (routeSteps[i].travel_mode == "TRANSIT") {
+      for (let j = 0; j < routeSteps[i].transit.line.agencies.length; j++) {
+        if (routeSteps[i].transit.line.agencies[j].name != "Dublin Bus") {
+          const step_duration = routeSteps[i].duration.text;
+          const travel_mode = "TRANSIT";
+          const provider = routeSteps[i].transit.line.agencies[j].name;
+          routeStepsData.step = {
+            step_duration: step_duration,
+            travel_mode: travel_mode,
+            provider: provider,
+          };
+        } else {
+          const travel_mode = "TRANSIT";
+          const provider = routeSteps[i].transit.line.agencies[j].name;
+          const bus_line_long_name = routeSteps[i].transit.line.name;
+          const bus_line_short_name = routeSteps[i].transit.line.short_name;
+          const headsign = routeSteps[i].transit.headsign;
+          const departure_stop = routeSteps[i].transit.departure_stop.name;
+          const arrival_stop = routeSteps[i].transit.arrival_stop.name;
+          // getting the number of stops should be useful to display cost of Dublin Bus journey
+          const number_of_stops = routeSteps[i].transit.num_stops;
+          routeStepsData.step = {
+            travel_mode: travel_mode,
+            provider: provider,
+            bus_line_long_name: bus_line_long_name,
+            bus_line_short_name: bus_line_short_name,
+            headsign: headsign,
+            departure_stop: departure_stop,
+            arrival_stop: arrival_stop,
+            number_of_stops: number_of_stops,
+          };
+        }
+      }
+    }
+    routeData.push(routeStepsData);
+  }
+  return routeData;
+}
+
+function displayRouteDetails() {
+  // this function will be implemented in another ticket/PR to display the details, including detailed steps, for the route
+  // when the user clicks the "route details" button
+  return;
 }

--- a/dublinbus/main/templates/main/index.html
+++ b/dublinbus/main/templates/main/index.html
@@ -15,14 +15,14 @@
 
     <div id="searchUI">
 
-    <p class="font-weight-bold text-center">Travelling From</p>
-    <div class="d-grid gap-2">
-      <button id="btn-primary" class="btn btn-primary" type="button">My Location</button>
-    </div>
+      <p class="font-weight-bold text-center">Travelling From</p>
+      <div class="d-grid gap-2">
+        <button id="btn-primary" class="btn btn-primary" type="button">My Location</button>
+      </div>
 
-    <div class="d-grid gap-2">
-      <p class="text-center">OR</p>
-    </div> 
+      <div class="d-grid gap-2">
+        <p class="text-center">OR</p>
+      </div> 
     
       <div class="form-group">
         <input type="text" class="form-control" id="origin" placeholder="Enter Location">
@@ -39,26 +39,26 @@
         <input type="datetime-local" id="departure-time" name="departure-time">
       </div>
 
-    <div class="d-grid gap-2">
-        <button id="submit" class="btn btn-primary" type="submit" onclick="calculateAndDisplayRoute(directionsService1, directionsRenderer1)">Submit</button>
-    </div>
+      <div class="d-grid gap-2">
+          <button id="submit" class="btn btn-primary" type="submit" onclick="calculateAndDisplayRoute(directionsService1, directionsRenderer1)">Submit</button>
+      </div>
 
-  </div>
+    </div>
 
     <div id="resultsUI" style="display: none">
 
-    <div id="directions_results"></div>
+      <div id="directions_results"></div>
+      <p class="text-center" id="user-error-message"></p>
 
-    <div class="d-grid gap-2">
-      <button id="clear" class="btn btn-primary" type="submit" onclick="clearDirections(directionsRenderer1)">Back to search</button>
-    </div>
+      <div class="d-grid gap-2">
+        <button id="submit_selected_route" class="btn btn-primary" type="submit" onclick="displayRouteDetails()">Route details</button>
+        <button id="clear" class="btn btn-primary" type="submit" onclick="clearDirections(directionsRenderer1)">Back to search</button>
+      </div>
 
     </div>
 
   </div>
-    
-
-  </div>
+ 
 </div>
 
 <script src="{% static 'journeyplanner.js' %}"></script>

--- a/dublinbus/main/urls.py
+++ b/dublinbus/main/urls.py
@@ -10,4 +10,9 @@ urlpatterns = [
     path("api/get_bus_stops", api.get_bus_stops, name="getbusstops"),
     path("api/weather_widget", api.weather_widget, name="weather_widget"),
     path("api/autocomple_route", api.autocomple_route, name="autocomple_route"),
+    path(
+        "api/get_journey_travel_time_estimation",
+        api.get_journey_travel_time_estimation,
+        name="gettraveltimes",
+    ),
 ]


### PR DESCRIPTION
## Context

This PR changes the display of the multiple suggested routes window and sends user input and routes' data from Frontend to Backend using method POST.

The data the backend receives is a dictionary containing two keys:
- departure_time (which value is the date and time selected by the user)
- routesData (which value is an array containing the relevant data for every suggested route that the backend will need to calculate the total time for that journey and return these total times back to the frontend)

Inside `routesData`:
- If a step of a route is not a Dublin Bus service, the dictionary will contain the predicted time by the google directions API.
- If a step of a route is a Dublin Bus service, the dictionary will contain departure and arrival stops, bus name and number, headsign, and the number of stops in the step so that these can be fed to our models to predict the travel time for the step.

In the backend we will be able then to sum our predicted times with the google's ones, whenever a route includes steps provided by Dublin Bus but also by other providers.

Note: I'll next work on displaying the detailed route steps that come from the google directions API response when the user clicks the "Route Details" button. So, at the moment, when the user clicks the "Route Details" button nothing happens.