### PR TITLE
Adds step duration for Dublin Bus steps

### DIFF
--- a/dublinbus/main/static/journeyplanner.js
+++ b/dublinbus/main/static/journeyplanner.js
@@ -273,6 +273,7 @@ function getRouteData(route) {
             provider: provider,
           };
         } else {
+          const step_duration = routeSteps[i].duration.text;
           const travel_mode = "TRANSIT";
           const provider = routeSteps[i].transit.line.agencies[j].name;
           const bus_line_long_name = routeSteps[i].transit.line.name;
@@ -283,6 +284,7 @@ function getRouteData(route) {
           // getting the number of stops should be useful to display cost of Dublin Bus journey
           const number_of_stops = routeSteps[i].transit.num_stops;
           routeStepsData.step = {
+            step_duration: step_duration,
             travel_mode: travel_mode,
             provider: provider,
             bus_line_long_name: bus_line_long_name,


### PR DESCRIPTION
## Context

This PR adds the `step_duration` field to the steps that entail a Dublin Bus journey so that in the backend we can use google's time estimation for that step if we don't have that route in our models (since our data can be outdated by now and google might suggest a new route that didn't exist before or because of other data issues).

- `step_durantion` will contain a string with the journey time estimation in minutes from the google API response object.

Initially, I was not sending the step duration for a Dublin Bus step assuming we would calculate the journey time for it using the models, but it was discussed in a meeting later that it could make sense to have it to cover the case of suggested routes that we don't have models for. 