### PR TITLE
Convert request data for feeding ML

### DIFF
--- a/dublinbus/main/api.py
+++ b/dublinbus/main/api.py
@@ -93,7 +93,9 @@ def get_journey_travel_time_estimation(request):
     if request.method == "POST":
         routesData = json.loads(request.body)
         # TODO access routes' data and format any data if necessary according to the data format the models were trained on
-        datetime_object = datetime.strptime(routesData["departure_time"], '%Y-%m-%dT%H:%M')
+        datetime_object = datetime.strptime(
+            routesData["departure_time"], "%Y-%m-%dT%H:%M"
+        )
         day_of_the_week = datetime_object.weekday()
         month_of_the_year = datetime_object.month
         hour_of_the_day = datetime_object.hour


### PR DESCRIPTION
### This PR
This PR converts the time and weather data from the frontend request. The week, month, hour and temperature are created based on [David's documentation](https://docs.google.com/document/d/1Sm1MJukS3U8673q0YC8nusa-nYUeMOe7vfHXLy5GqYw/edit).
### Next PR (need to be discussed)
The weather_main has not been converted to dummy variables in this PR. There are still something that we need to discuss. 

Every type of weather_main in David's documentation is included in OpenWeather API, but OpenWeather API has even more types of weather_main. So, for example, we need to identify what we will do when weather_main is Clear.
https://openweathermap.org/weather-conditions

