### PR TITLE
added icon clustering

### DIFF
--- a/dublinbus/main/static/realtime.js
+++ b/dublinbus/main/static/realtime.js
@@ -34,7 +34,7 @@ function getAllBusStops() {
           },
           icon: {
             url: "http://maps.google.com/mapfiles/kml/paddle/ylw-circle.png",
-            scaledSize: new google.maps.Size(50, 50),
+            scaledSize: new google.maps.Size(40, 40),
           },
           map,
         });
@@ -48,6 +48,10 @@ function getAllBusStops() {
           map.panTo(newMarker.getPosition());
         });
       }
+      new MarkerClusterer(map, markers, {
+        imagePath:
+          "https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m",
+      });
     })
     .catch((error) => {
       console.log(error);

--- a/dublinbus/main/templates/main/realtime.html
+++ b/dublinbus/main/templates/main/realtime.html
@@ -9,7 +9,7 @@
 {% block content %}
   <div id="map"></div>
 
-
+  <script src="https://unpkg.com/@googlemaps/markerclustererplus/dist/index.min.js"></script>
   <script src="{% static 'realtime.js' %}"></script>
 {% endblock %}
 


### PR DESCRIPTION
Small PR which adds **Icon Clustering for the Realtime Info page**.

This way the map does not appear cluttered with too many markers, since there are so many bus stops throughout Dublin.

This was surprisingly easy to implement as it is a simple official add on for the Maps API.

Clicking on a circle representing multiple markers, will zoom the user to the area containing those markers.

Here is what the Map looks like now at different zoom levels:

<img width="1522" alt="2021-07-29 (10)" src="https://user-images.githubusercontent.com/70216693/127533316-b0be17af-b980-45be-a8d5-3aec82f0b9c8.png">

<img width="1518" alt="2021-07-29 (11)" src="https://user-images.githubusercontent.com/70216693/127533325-ae88b04a-f83b-4fa9-b8bc-4cf32c57462b.png">

<img width="1526" alt="2021-07-29 (12)" src="https://user-images.githubusercontent.com/70216693/127533328-978efc10-bdf7-4c65-b462-da93d9e7849d.png">
