### PR TITLE
added geolocation in Journey Planner

### DIFF
--- a/dublinbus/main/static/journeyplanner.js
+++ b/dublinbus/main/static/journeyplanner.js
@@ -183,17 +183,25 @@ locationButton = document.getElementById("location_button");
 originField = document.getElementById("origin");
 
 function reverse_geocoder(latitude, longitude) {
-
   var xmlhttp1 = new XMLHttpRequest();
   var parsedResponse;
 
-  xmlhttp1.onreadystatechange = function() {
-      if (xmlhttp1.readyState == 4 && xmlhttp1.status == 200) { 
-          parsedResponse = JSON.parse(xmlhttp1.responseText);
-          originField.value = parsedResponse['results'][0].formatted_address;
-      }
-  }
-  xmlhttp1.open("GET", "https://maps.googleapis.com/maps/api/geocode/json?latlng=" + latitude + "," + longitude + "&key=APIKEY", true);
+  xmlhttp1.onreadystatechange = function () {
+    if (xmlhttp1.readyState == 4 && xmlhttp1.status == 200) {
+      parsedResponse = JSON.parse(xmlhttp1.responseText);
+      originField.value = parsedResponse["results"][0].formatted_address;
+    }
+  };
+  xmlhttp1.open(
+    "GET",
+    "https://maps.googleapis.com/maps/api/geocode/json?latlng=" +
+      latitude +
+      "," +
+      longitude +
+      "&key=" +
+      google_api_key,
+    true
+  );
   xmlhttp1.send();
 }
 

--- a/dublinbus/main/templates/main/index.html
+++ b/dublinbus/main/templates/main/index.html
@@ -61,6 +61,10 @@
   var csrftoken = '{{ csrf_token }}';
 </script>
 
+<script>
+  var google_api_key = '{{ GOOGLEMAPS_APIKEY }}';
+</script>
+
 <script src="{% static 'journeyplanner.js' %}"></script>
 
 {% endblock %}


### PR DESCRIPTION
This push adds **Geolocation functionality to the Journey Planner interface**.

The user can click the My Location button and **if they allow permissions** through their browser, the coordinates of their location will be **automatically filled in the Origin field**.

If the user does not allow location permissions, an error message will be displayed through their browser and the button will have no functionality.

Error catching also exists for the user's browser not supporting Geolocation.

Here is a demo video of the functionality.


https://user-images.githubusercontent.com/70216693/127544008-7fb8cf93-b038-4218-a6da-351ea7d6d875.mp4



It should be noted that in my case, the coordinates found were not 100% accurate (though they were correct finding in my town). These are the same coordinates that the Google Maps website itself finds when I use their location feature. I presume this is because I am on a desktop with no GPS, and the location is probably being found from my ISP (and therefore the location is actually the location of a Virgin Media network hub).

I imagine **the feature will be more accurate on mobile devices which do have GPS** and other location functionalities. But we will not know for certain until this is deployed on Heroku.