### PR TITLE
Error message bug

### DIFF
--- a/dublinbus/main/static/routeviewer.js
+++ b/dublinbus/main/static/routeviewer.js
@@ -262,6 +262,7 @@ function getBusStopsByBusNum(routeNumber) {
         busRoutes.constructor === Object
       ) {
         // display error message if the object is empty
+        document.getElementById("user-error-message").style.display = "block";
         document.getElementById("user-error-message").innerText =
           "Please enter a valid route number";
         return;


### PR DESCRIPTION
## Bug

- When we checkout PR#34, we will see an error message in the window, if we sumbit an invalid route number, as the screenshot below.

![image](https://user-images.githubusercontent.com/71880332/127562615-497889d8-c8d3-41a4-bab9-e239413687fb.png)
![image](https://user-images.githubusercontent.com/71880332/127562638-2c7b3687-7abb-4dd3-86a9-916222da2d2e.png)



- But, after PR#37, when we sumbit an invalid route number, no message will be shown in the window.

![image](https://user-images.githubusercontent.com/71880332/127562746-42224934-cbbd-47f9-be36-b133b4d30490.png)
![image](https://user-images.githubusercontent.com/71880332/127562759-080c496f-9e63-41d6-9c57-7a64af8ea097.png)


##  How to fix it

The cause of this bug is this style.css (see the screenshot below). Because this css file is shared by every page, and we added the following codes in PR#37 that makes the message box in the route page not working, although that PR was only for the journey planner page.

But, it is easy to fix. We just need to add one line to the javascript file to fix this bug (see the commit of the current PR).

![image](https://user-images.githubusercontent.com/71880332/127562467-e9a593ad-008e-4e01-9577-37e15f09faa0.png)