### PR TITLE
Replace or hide google's travel time estimations on frontend using our KNN models predictions

### DIFF
--- a/dublinbus/main/api.py
+++ b/dublinbus/main/api.py
@@ -9,6 +9,7 @@ from django.db.models import Q
 import pandas as pd
 import joblib
 from datetime import timedelta
+import time
 
 # returns all bus stops for each direction of each bus route
 def get_bus_stops(request):
@@ -214,9 +215,21 @@ def _get_travel_time_for_route(route, user_datetime_object):
 
     total_seconds = timedelta(seconds=route_total_time)
     end_time_datetime_object = start_time_datetime_object + total_seconds
+    # convert route total time in seconds to string with hours and mins to send to frontend already formatted
+    if route_total_time > 3600:
+        if route_total_time < 7200:
+            route_duration = time.strftime(
+                "%-H hour %-M mins", time.gmtime(route_total_time)
+            )
+        else:
+            route_duration = time.strftime(
+                "%-H hours %-M mins", time.gmtime(route_total_time)
+            )
+    else:
+        route_duration = time.strftime("%-M mins", time.gmtime(route_total_time))
 
     # add total time in seconds we estimate the route will take to the routes predictions dict
-    route_travel_prediction["total_time_seconds"] = route_total_time
+    route_travel_prediction["route_duration"] = route_duration
 
     # add final clock time of the journey to the routes_predictions dict
     route_travel_prediction["journey_ends"] = _datetime_to_hour_minutes_string(


### PR DESCRIPTION
## Context

This PR follows up on [PR#53](https://github.com/sn-lp/Dublin-Bus-Project-Team-14/pull/53) and uses the travel time estimations being calculated in the backend and returned to the frontend to display travel time estimations.

#### How it looks currently with our estimations in place 
![journeyplanner_final](https://user-images.githubusercontent.com/66690399/128731678-722e6662-62a6-4eb9-b07b-dc347b0b2ab0.gif)

#### Notes
1. all the times you see displayed for the suggested routes are being injected into the HTML elements which are injected by google API when calling `directionsRenderer.[method]`; 
2. these times come from the object returned by the backend (i.e. `estimationsResponse` on `journeyplanner.js`);
3. as mentioned in PR#53, for now, the clock times in the `Route Details` view are hidden --> this is because in order to display this from our own calculations there's some work to be done in the backend to calculate times for individual steps of a route (at the moment the backend is calculating only the overall time for each route). Another ticket will then follow up on this to make the necessary changes. So for now, the highlighted section below is hidden as you can see in the gif above.

      <img width="367" alt="Screenshot 2021-08-09 at 16 41 51" src="https://user-images.githubusercontent.com/66690399/128734362-ced22edb-7fe9-4328-bb7d-5e8aced8fe7e.png">


4. inside`replaceOrHideStepTimes()` function you'll see this code:
      `tableRow.setAttribute("jsaction", " ");`
      - this is to disable a feature (already built-in by google) that when the user clicks a step of a route it displays an infowindow on the map and inside that infowindow it shows the clock times from google that are being hidden for now as mentioned above in the steps' details. After the above-mentioned work (number 3) in the backend is concluded I'll be able to enable the infowindow again and replace the times there with our owns too.
      - to make more clear what this infowindow is, here is a demo gif that shows the infowindow at the end (but as mentioned, infowindow is disabled in this PR):
      ![journeyplanner_times_replaced](https://user-images.githubusercontent.com/66690399/128733444-737fc3f4-7513-4538-8fdf-09d929650d6a.gif)
