### PR TITLE
Fix strftime to work both on Mac and Windows

### DIFF
--- a/dublinbus/main/api.py
+++ b/dublinbus/main/api.py
@@ -10,6 +10,7 @@ import pandas as pd
 import joblib
 from datetime import timedelta
 import time
+import os
 
 
 # returns all bus stops for each direction of each bus route
@@ -285,18 +286,26 @@ def _get_travel_time_for_route(route, user_datetime_object):
 
     total_seconds = timedelta(seconds=route_total_time)
     end_time_datetime_object = start_time_datetime_object + total_seconds
+    if os.name == "nt":
+        time_format_os_specific = "#"
+    else:
+        time_format_os_specific = "-"
     # convert route total time in seconds to string with hours and mins to send to frontend already formatted
     if route_total_time > 3600:
         if route_total_time < 7200:
             route_duration = time.strftime(
-                "%-H hour %-M mins", time.gmtime(route_total_time)
+                f"%{time_format_os_specific}H hour %{time_format_os_specific}M mins",
+                time.gmtime(route_total_time),
             )
         else:
             route_duration = time.strftime(
-                "%-H hours %-M mins", time.gmtime(route_total_time)
+                f"%{time_format_os_specific}H hours %{time_format_os_specific}M mins",
+                time.gmtime(route_total_time),
             )
     else:
-        route_duration = time.strftime("%-M mins", time.gmtime(route_total_time))
+        route_duration = time.strftime(
+            f"%{time_format_os_specific}M mins", time.gmtime(route_total_time)
+        )
 
     # add total time in seconds we estimate the route will take to the routes predictions dict
     route_travel_prediction["route_duration"] = route_duration

--- a/dublinbus/main/static/journeyplanner.js
+++ b/dublinbus/main/static/journeyplanner.js
@@ -636,7 +636,6 @@ function getSelectedRouteIndex() {
 
 function displayErrorMessageToUser() {
   // display error message to the user if the injected html elements expected from calling "directionsRenderer.setPanel" are not available
-  console.log(document.getElementById("directions_results").children[1]);
   if (
     document.getElementById("directions_results").children[1].style.display ==
     "block"


### PR DESCRIPTION
## Context

Using `time.strftime` on `api.py` with `-` before hour and minutes to remove leading zeros was not working on Windows since on Windows the same functionality is achieved with `#`.
So this PR modifies the code to check the Operating System running the app and to use `#` instead of `-` when OS is Windows.

P.s.: this PR also removes a console.log that was actually on `journeyplanner.js` by mistake and that I thought had been removed. :)