### PR TITLE
Add fields to api response for quantile plots

### DIFF
--- a/dublinbus/main/api.py
+++ b/dublinbus/main/api.py
@@ -292,6 +292,7 @@ def _get_travel_time_for_route(route, user_datetime_object):
             step_duration,
             step_estimated_cost,
             route_name,
+            predicted_by_app,
         ) = _get_step_time_estimation(
             route_step_dict, user_datetime_object, elapsed_time
         )
@@ -305,6 +306,7 @@ def _get_travel_time_for_route(route, user_datetime_object):
             "prediction_in_seconds": step_time_estimation,
             "step_cost": step_estimated_cost,
             "route_name": route_name,
+            "predicted_by_app": predicted_by_app,
         }
         elapsed_time += timedelta(seconds=step_time_estimation)
         step_index += 1
@@ -332,6 +334,7 @@ def _get_step_time_estimation(route_step_dict, user_datetime_object, elapsed_tim
     step_duration = ""
     step_estimated_cost = ""
     route_name = ""
+    predicted_by_app = False
 
     if not "step" in route_step_dict or not "step_duration" in route_step_dict["step"]:
         return (
@@ -342,6 +345,7 @@ def _get_step_time_estimation(route_step_dict, user_datetime_object, elapsed_tim
             step_duration,
             step_estimated_cost,
             route_name,
+            predicted_by_app,
         )
 
     google_travel_time_prediction = route_step_dict["step"]["step_duration"]
@@ -400,6 +404,7 @@ def _get_step_time_estimation(route_step_dict, user_datetime_object, elapsed_tim
             step_duration,
             step_estimated_cost,
             route_name,
+            predicted_by_app,
         )
     else:
         route_shortname = route_step_dict["step"]["bus_line_short_name"]
@@ -421,6 +426,7 @@ def _get_step_time_estimation(route_step_dict, user_datetime_object, elapsed_tim
                 step_duration,
                 step_estimated_cost,
                 route_name,
+                predicted_by_app,
             )
 
         trip_headsign = route_step_dict["step"]["bus_line_long_name"]
@@ -453,6 +459,7 @@ def _get_step_time_estimation(route_step_dict, user_datetime_object, elapsed_tim
                 step_duration,
                 step_estimated_cost,
                 route_name,
+                predicted_by_app,
             )
 
         trip_id = matching_trip.id
@@ -480,6 +487,7 @@ def _get_step_time_estimation(route_step_dict, user_datetime_object, elapsed_tim
                 step_duration,
                 step_estimated_cost,
                 route_name,
+                predicted_by_app,
             )
 
         matching_arrival_stop = Stop.objects.filter(Q(name=arrival_stop)).first()
@@ -505,6 +513,7 @@ def _get_step_time_estimation(route_step_dict, user_datetime_object, elapsed_tim
                 step_duration,
                 step_estimated_cost,
                 route_name,
+                predicted_by_app,
             )
 
         # make predictions if all necessary values are available
@@ -535,6 +544,7 @@ def _get_step_time_estimation(route_step_dict, user_datetime_object, elapsed_tim
         elapsed_time += timedelta(seconds=step_time_estimation)
         step_ends = _datetime_to_hour_minutes_string(elapsed_time)
         step_duration = _convert_number_of_seconds_to_time_string(step_time_estimation)
+        predicted_by_app = True
         return (
             step_time_estimation,
             step_number_of_stops,
@@ -543,6 +553,7 @@ def _get_step_time_estimation(route_step_dict, user_datetime_object, elapsed_tim
             step_duration,
             step_estimated_cost,
             route_name,
+            predicted_by_app,
         )
 
 

--- a/dublinbus/main/tests.py
+++ b/dublinbus/main/tests.py
@@ -447,6 +447,7 @@ class ApiTests(TestCase):
             step_duration,
             step_estimated_cost,
             route_name,
+            predicted_by_app,
         ) = _get_step_time_estimation(step_data_example, datetime_object, elapsed_time)
         # assert returned values are as expected for this step
         self.assertEqual(
@@ -466,6 +467,7 @@ class ApiTests(TestCase):
         )
         self.assertEqual(step_estimated_cost, "")
         self.assertEqual(route_name, "")
+        self.assertEqual(predicted_by_app, False)
 
     def test_get_step_time_estimation_step_not_dublin_bus(self):
         step_data_example = {
@@ -488,6 +490,7 @@ class ApiTests(TestCase):
             step_duration,
             step_estimated_cost,
             route_name,
+            predicted_by_app,
         ) = _get_step_time_estimation(step_data_example, datetime_object, elapsed_time)
         # assert returned values are as expected for this step
         self.assertEqual(
@@ -507,6 +510,7 @@ class ApiTests(TestCase):
         )
         self.assertEqual(step_estimated_cost, "")
         self.assertEqual(route_name, "")
+        self.assertEqual(predicted_by_app, False)
 
     def test_get_step_time_estimation_step_dublin_bus_not_in_db(self):
         dublin_bus_step_not_exists_in_db = {
@@ -535,6 +539,7 @@ class ApiTests(TestCase):
             step_duration,
             step_estimated_cost,
             route_name,
+            predicted_by_app,
         ) = _get_step_time_estimation(
             dublin_bus_step_not_exists_in_db, datetime_object, elapsed_time
         )
@@ -557,6 +562,7 @@ class ApiTests(TestCase):
         )
         self.assertEqual(step_estimated_cost, "€2.50")
         self.assertEqual(route_name, "46A")
+        self.assertEqual(predicted_by_app, False)
 
     def test_datetime_to_hour_minutes_string_until_10_mins(self):
         datetime_object = datetime.strptime(


### PR DESCRIPTION
## Context

This PR adds three fields to the backend API response to include the route name and prediction in seconds for each step of a route and also if the prediction was made by the app or not. This is necessary to make a request to the backend to generate a quantile dot plot for a step of a route if it is from Dublin Bus (what Kyle is working on at the moment).
 
Fields added:
- `predicted_by_app`: boolean
- `route_name`: will be empty `""` if not a Dublin Bus step
- `prediction_in_seconds` 

These are available in `journeyplanner.js` in `travelTimeEstimations`.

#### Note:
I assumed we only want to generate the plots for steps predicted by the app and added the boolean field that we could check the value of, but if the assumption is incorrect I can remove the `predicted_by_app` field from the api response. :)

##### Screenshots demonstrating the object according to the suggested route (you can see the first step is from Dublin Bus but the app was not able to predict - because "UCD N11 Entrance" stop does not exist in the DB - so `predicted_by_app` gets value False but the other gets value True).
<img width="1440" alt="Screenshot 2021-08-12 at 22 17 10" src="https://user-images.githubusercontent.com/66690399/129271959-ed30e5fb-037e-4cab-b727-c0aa1010c729.png">
