### PR TITLE
Add loading button to journey planner interface

### DIFF
--- a/dublinbus/main/static/journeyplanner.js
+++ b/dublinbus/main/static/journeyplanner.js
@@ -42,6 +42,7 @@ document
 
 //Directions
 function calculateAndDisplayRoute(directionsService, directionsRenderer) {
+  document.getElementById("loading").style.display = "block";
   // hide over_map until we replaced the times in the suggested routes div
   document.getElementById("over_map").style.display = "none";
 
@@ -106,6 +107,9 @@ function calculateAndDisplayRoute(directionsService, directionsRenderer) {
     .catch((e) => {
       console.log(e);
       window.alert("No bus directions could be found");
+      document.getElementById("loading").style.display = "none";
+      // make window reload to prompt the user to enter a new origin/destination address if no bus connection could be found for the previous submission
+      window.location.reload();
     });
 }
 
@@ -296,6 +300,7 @@ function getRoutesTravelEstimationsFromModels(
       travelTimeEstimations = estimationsResponse;
       replaceTravelTimeEstimations(travelTimeEstimations);
       timeEstimationReplaced = true;
+      document.getElementById("loading").style.display = "none";
       document.getElementById("directions_results").children[0].style.display =
         "block";
       document.getElementById("over_map").style.display = "block";

--- a/dublinbus/main/static/style.css
+++ b/dublinbus/main/static/style.css
@@ -250,3 +250,19 @@ ripple-surface {
   display: block;
   z-index: 50;
 }
+
+#loading {
+  position: absolute;
+  top: 15vh;
+  left: 3vw;
+  z-index: 0;
+  display: none;
+}
+/* Implementation of loading button follows instructions on https://www.w3schools.com/howto/howto_css_loading_buttons.asp */
+.buttonload {
+  background-color: #ffcc00;
+  border: none; /* Remove borders */
+  color: black;
+  padding: 12px 16px; /* Some padding */
+  font-size: 16px; /* Set a font size */
+}

--- a/dublinbus/main/templates/main/base.html
+++ b/dublinbus/main/templates/main/base.html
@@ -13,6 +13,7 @@
       <link rel="stylesheet" type="text/css" href="{% static 'style.css' %}" />
       <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
       <link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
       <script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
       <title>{% block title %}{{ title }}{% endblock %}</title>
     </head>

--- a/dublinbus/main/templates/main/index.html
+++ b/dublinbus/main/templates/main/index.html
@@ -11,6 +11,12 @@
 <div id="wrapper">
   <div id="map"></div>
 
+  <div id="loading">
+    <button class="buttonload">
+      <i class="fa fa-spinner fa-spin"></i>Loading routes
+    </button>
+  </div>
+
   <div id="over_map" class="container w-25 p-3 bg-white">
 
     <div id="searchUI">


### PR DESCRIPTION
## Context

This PR adds a loading button following a [W3schools guide](https://www.w3schools.com/howto/howto_css_loading_buttons.asp). This button displays after the user clicks submit and until the suggested routes results are displayed.

#### Preview
![journeyplanner_loading_button](https://user-images.githubusercontent.com/66690399/129719996-c373242d-5203-40f2-9369-e2a552778db6.gif)

##### Note
I also added a line of code to make the page reload after a "No bus directions could be found" alert window is displayed so to prompt the user to make a new search. Otherwise, the page is left displaying just the map. 
Now the behaviour would be like:
![journeyplanner_reloading_page](https://user-images.githubusercontent.com/66690399/129720159-9047f56d-c021-4329-96bf-e6e1825859f5.gif)
