### PR TITLE
Display map button tooltip upon opening app on browser

### DIFF
--- a/dublinbus/main/static/app.js
+++ b/dublinbus/main/static/app.js
@@ -1,3 +1,23 @@
+// initialise map button tooltip
+const mapToggle = document.getElementById("map_toggle");
+const tooltip = new mdb.Tooltip(mapToggle);
+
+displayMapButtonTooltip(tooltip);
+
+// display the tooltip only the first time the user opens the app in one browser
+function displayMapButtonTooltip(mapButtonTooltip) {
+  if (typeof Storage !== "undefined") {
+    if (localStorage.getItem("map_tooltip_displayed") == null) {
+      tooltip.show();
+      // display toggle map button for 4 seconds and then hide it
+      setTimeout(function () {
+        mapButtonTooltip.hide();
+      }, 4000);
+      localStorage.setItem("map_tooltip_displayed", true);
+    }
+  }
+}
+
 //Navigation Drawer
 const drawer = mdc.drawer.MDCDrawer.attachTo(
   document.querySelector(".mdc-drawer")

--- a/dublinbus/main/static/style.css
+++ b/dublinbus/main/static/style.css
@@ -50,7 +50,7 @@ button.btn:hover {
 
 #over_map {
   position: absolute;
-  top: 10vh;
+  top: 120px;
   left: 3vw;
   z-index: 0;
   min-width: 370px;
@@ -271,4 +271,22 @@ ripple-surface {
   color: black;
   padding: 12px 16px; /* Some padding */
   font-size: 16px; /* Set a font size */
+}
+
+/* Using color tool guidelines https://material.io/resources/color/#!/?view.left=1&view.right=1&primary.color=25B5F1&secondary.color=FFCC00 */
+/* setting !important to be able to overwrite mdb and bootstrap default styling */
+.tooltip,
+.tooltip-arrow {
+  display: block !important;
+  border-bottom-color: #c79c00 !important;
+}
+
+.tooltip-inner {
+  background-color: #c79c00 !important;
+  color: black !important;
+  opacity: 90% !important;
+}
+
+.tooltip-arrow::before {
+  border-bottom-color: #c79c00 !important;
 }

--- a/dublinbus/main/templates/main/base.html
+++ b/dublinbus/main/templates/main/base.html
@@ -52,7 +52,15 @@
               <h3>{% block nav_title %}{{ nav_title }}{% endblock %}</h3>
             </div>
 
-            <button class="mdc-icon-button material-icons" id="map_toggle" style="color: black;">map</button>
+            <button 
+              class="mdc-icon-button material-icons" 
+              id="map_toggle" 
+              type="button"
+              data-mdb-toggle="tooltip"
+              data-mdb-placement="bottom"
+              data-mdb-trigger="manual"
+              title="Click this button to view the Map" 
+              style="color: black;">map</button>
 
             <img class="d-none d-lg-block" src="{% static 'img/db_logo.png' %}" alt="dublin_bus_logo" height="45px" /></img>
             <div class="d-none d-lg-block">
@@ -72,10 +80,10 @@
 
     <main id="container-fluid">{% block content %}{% endblock %}</main>
     
-    <script src="{% static 'app.js' %}"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLEMAPS_APIKEY }}&callback=initMap&libraries=places&v=weekly" async></script>
     <script src="{% static 'main/js/bootstrap.js' %}"></script>
     <script src="{% static 'main/MDB/js/mdb.min.js' %}"></script>
+    <script src="{% static 'app.js' %}"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLEMAPS_APIKEY }}&callback=initMap&libraries=places&v=weekly" async></script>
   </body>
 
 </html>


### PR DESCRIPTION
## Context

This PR adds a tooltip to the map toggle button that displays upon opening the app for the first time in one browser. This is to address user feedback we received about not being clear what is the functionality of the map button. 

#### Preview

![journeyplanner_tooltip](https://user-images.githubusercontent.com/66690399/129904489-57f949e7-5dbb-41db-9e78-eb1e88e960c0.gif)

##### Notes
- The tooltip is set up to display for 4 seconds and be hidden after that.
- This uses the browser's local storage to store if the tooltip was already displayed or not so that the tooltip doesn't show every time the user opens the app. You can see in the GIF that when I refresh the page the tooltip does not show again.
- I had to move the over_map div a little lower so that the tooltip is not displayed over it.