### PR TITLE
Remove commented code from routeviewer.js

### DIFF
--- a/dublinbus/main/static/routeviewer.js
+++ b/dublinbus/main/static/routeviewer.js
@@ -221,14 +221,6 @@ function removeFromLocalstorage(routeNumber) {
   }
 }
 
-// KYLE COMMENTED OUT FOR NOW - I THINK THIS MAKES THE UI LESS USABLE
-// function resetMapPositionAndZoom() {
-//   map.setZoom(defaultMapZoomLevel);
-//   map.setCenter(
-//     new google.maps.LatLng(defaultMapPositionLat, defaultMapPositionLong)
-//   );
-// }
-
 function changeDirection(directionNumber) {
   // resetMapPositionAndZoom();
   // Get the container element


### PR DESCRIPTION
## Context

This PR removes a function that was commented on `routeviewer.js`.