### PR TITLE
Add aria labels and alternative text

### DIFF
--- a/dublinbus/main/static/app.js
+++ b/dublinbus/main/static/app.js
@@ -61,12 +61,15 @@ function getWeatherFromBackend() {
         "src",
         "http://openweathermap.org/img/wn/" + weather_icon_id + "@2x.png"
       );
+      weather_widget_image.setAttribute("alt", "weather widget");
       document
         .getElementById("weather_widget_top")
         .appendChild(weather_widget_image);
 
       var weather_widget_temperature = document.createElement("h5");
       weather_widget_temperature.innerText = weather_temperature;
+      weather_widget_temperature.id = "temperature";
+      weather_widget_temperature.setAttribute("aria-labelledby", "temperature");
       document
         .getElementById("weather_widget_top")
         .appendChild(weather_widget_temperature);

--- a/dublinbus/main/templates/main/base.html
+++ b/dublinbus/main/templates/main/base.html
@@ -25,14 +25,14 @@
     <aside class="mdc-drawer mdc-drawer--modal d-lg-none">
       <div class="mdc-drawer__content">
         <nav class="mdc-list">
-          <img class="mdc-list-item" src="{% static 'img/db_logo.png' %}" alt="dublin_bus_logo" height="45px" /></img>
-          <a class="mdc-list-item" href="/" tabindex="0" aria-current="page">
+          <img class="mdc-list-item" src="{% static 'img/db_logo.png' %}" alt="dublin bus logo" height="45px" /></img>
+          <a class="mdc-list-item" href="/" tabindex="0" aria-current="page" aria-label="go to journey planner page">
             Journey Planner
           </a>
-          <a class="mdc-list-item" href="/realtime/" tabindex="0">
+          <a class="mdc-list-item" href="/realtime/" tabindex="0" aria-label="go to real time info page">
             Real Time Info
           </a>
-          <a class="mdc-list-item" href="/busroutes/" tabindex="0">
+          <a class="mdc-list-item" href="/busroutes/" tabindex="0" aria-label="go to routes page">
             Routes
           </a>
         </nav>
@@ -45,7 +45,9 @@
       <header class="mdc-top-app-bar mdc-top-app-bar--fixed">
         <div class="mdc-top-app-bar__row">
           <section class="mdc-top-app-bar__section ">
-            <button class="material-icons mdc-top-app-bar__navigation-icon mdc-icon-button d-lg-none" style="color: black;">menu</button>
+            <button class="material-icons mdc-top-app-bar__navigation-icon mdc-icon-button d-lg-none"
+            style="color: black;"
+            aria-label="menu">menu</button>
 
             <div class="mx-auto d-lg-none">
               <img src="{% static 'img/db_icon.png' %}" alt="dublin_bus_icon" height="45px" /></img>
@@ -56,20 +58,21 @@
               class="mdc-icon-button material-icons" 
               id="map_toggle" 
               type="button"
+              aria-label="toggle map view"
               data-mdb-toggle="tooltip"
               data-mdb-placement="bottom"
               data-mdb-trigger="manual"
               title="Click this button to view the Map" 
               style="color: black;">map</button>
 
-            <img class="d-none d-lg-block" src="{% static 'img/db_logo.png' %}" alt="dublin_bus_logo" height="45px" /></img>
+            <img class="d-none d-lg-block" src="{% static 'img/db_logo.png' %}" alt="dublin bus logo" height="45px" /></img>
             <div class="d-none d-lg-block">
-              <a class="mdc-top-app-bar--fixed" id="journeyplanner_nav" href="/">Journey Planner</a>
-              <a class="mdc-top-app-bar--fixed" id="realtime_nav" href="/realtime/">Real Time Info</a>
-              <a class="mdc-top-app-bar--fixed" id="routes_nav" href="/busroutes/">Routes</a>
+              <a class="mdc-top-app-bar--fixed" id="journeyplanner_nav" href="/" aria-label="go to journey planner page">Journey Planner</a>
+              <a class="mdc-top-app-bar--fixed" id="realtime_nav" href="/realtime/" aria-label="go to real time info page">Real Time Info</a>
+              <a class="mdc-top-app-bar--fixed" id="routes_nav" href="/busroutes/" aria-label="go to routes page">Routes</a>
             </div>
 
-            <div class="d-none d-lg-block float-right" id="weather_widget_top">
+            <div class="d-none d-lg-block float-right" id="weather_widget_top" alt="weather widget">
             </div>
 
           </section>

--- a/dublinbus/main/templates/main/index.html
+++ b/dublinbus/main/templates/main/index.html
@@ -12,57 +12,72 @@
   <div id="map"></div>
 
   <div id="loading">
-    <button class="buttonload">
+    <button class="buttonload" alt="loading routes">
       <i class="fa fa-spinner fa-spin"></i>Loading routes
     </button>
   </div>
 
   <div id="over_map" class="container w-25 p-3 bg-white">
 
-    <div id="searchUI">
+    <div id="searchUI" role="journey planner" aria-label="search a route between origin and destination locations">
 
       <p class="font-weight-bold text-center"><label for="origin">Travelling From</label></p>
       <div class="d-grid gap-2">
-        <button id="location_button" class="btn btn-primary" type="button">
+        <button id="location_button" class="btn btn-primary" type="button" aria-label="use my location for origin address">
           <img src="{% static 'img/location.png' %}" alt="my_location" height="15px" /></img>
           Use My Location
         </button>
       </div>
     
       <div class="form-group">
-        <input type="text" class="form-control" id="origin" placeholder="Enter Location">
+        <input type="text" class="form-control" id="origin" placeholder="Enter Location" aria-label="origin address">
       </div>
       
       <p class="font-weight-bold text-center"><label for="destination">Destination</label></p>
       <div class="form-group">
-        <input type="text" class="form-control" id="destination" placeholder="Enter Destination">
+        <input type="text" class="form-control" id="destination" placeholder="Enter Destination" aria-label="destination address">
       </div>
 
       <p class="font-weight-bold text-center"><label for="departure-time">Departure Time</label></p>
 
       <div class="form-outline datepicker">
-        <input type="datetime-local" id="departure-time" name="departure-time">
+        <input type="datetime-local" id="departure-time" name="departure-time" aria-label="departure time">
       </div>
 
       <div class="d-grid gap-2">
-          <button id="submit" class="btn btn-primary" type="submit" onclick="calculateAndDisplayRoute(directionsService1, directionsRenderer1)">Submit</button>
+        <button
+          id="submit"
+          class="btn btn-primary"
+          type="submit"
+          aria-label="submit"
+          onclick="calculateAndDisplayRoute(directionsService1, directionsRenderer1)">Submit</button>
       </div>
 
     </div>
 
     <div id="resultsUI" style="display: none">
 
-      <div id="directions_results"></div>
+      <div id="directions_results"  role="routes" aria-label="suggested routes"></div>
       <p class="text-center" id="user-error-message"></p>
 
       <div class="d-grid gap-2">
-        <button id="submit-selected-route" class="btn btn-primary" type="submit" onclick="displayRouteDetails()">Route details</button>
-        <button id="clear" class="btn btn-primary" type="submit" onclick="clearDirections(directionsRenderer1)">Back to search</button>
-        <button id="back-to-routes" class="btn btn-primary" type="submit" onclick="displaySuggestedRoutes()">Back to routes</button>
-      </div>
-
-      <div id="dotplot">
-
+        <button
+          id="submit-selected-route"
+          class="btn btn-primary"
+          type="submit"
+          aria-label="see route details"
+          onclick="displayRouteDetails()">Route details</button>
+        <button
+          id="clear"
+          class="btn btn-primary"
+          type="submit"
+          onclick="clearDirections(directionsRenderer1)">Back to search</button>
+        <button
+          id="back-to-routes"
+          class="btn btn-primary"
+          type="submit"
+          aria-label="go back to suggested routes"
+          onclick="displaySuggestedRoutes()">Back to routes</button>
       </div>
 
     </div>

--- a/dublinbus/main/templates/main/realtime.html
+++ b/dublinbus/main/templates/main/realtime.html
@@ -18,40 +18,64 @@
 
   <div id="over_map" class="container w-25 p-3 bg-white">
 
-    <div id="searchStopUI">
+    <div id="searchStopUI" role="search" aria-label="search a bus stop">
       <p class="font-weight-bold text-center">Select a Bus Stop on Map or Search</p>
 
       <div class="form-group">
         <p class="text-center" id="user-error-message"></p>
         <div id="autocomplete" class="autocomplete">
-          <input class="autocomplete-input form-control" type="text" id="bus-stop-input" placeholder="Bus Stop"/>
+          <input
+            class="autocomplete-input form-control"
+            type="text" id="bus-stop-input"
+            placeholder="Bus Stop"
+            aria-label="bus stop"/>
           <ul class="autocomplete-result-list"></ul>
         </div>
       </div>
 
       <div class="d-grid gap-2">
-          <button id="submit" class="btn btn-primary" type="submit" onclick="call_realtime_from_search()">Submit</button>
+        <button 
+          id="submit"
+          class="btn btn-primary"
+          type="submit"
+          aria-label="submit bus stop"
+          onclick="call_realtime_from_search()">Submit</button>
       </div>
 
-      <div id = "favourites">
+      <div id="favourites" aria-label="favourite stops">
       
       </div>
     </div>
 
-    <p class="font-weight-bold text-center" id="stop_name_box"></p>
+    <p class="font-weight-bold text-center" id="stop_name_box" alt="bus stop name"></p>
     
 
     <div class="d-grid gap-2">
-      <button id="add-to-favourites" class="btn btn-primary" type="button" onclick="addToLocalstorage()">Add to Favourites</button>
-      <button id="remove-from-favourites" class="btn btn-primary" type="button">Remove from Favourites</button>
+      <button
+        id="add-to-favourites"
+        class="btn btn-primary"
+        type="button"
+        aria-label="add stop to favourites"
+        onclick="addToLocalstorage()">Add to Favourites</button>
+      <button
+        id="remove-from-favourites"
+        class="btn btn-primary"
+        type="button"
+        aria-label="remove stop from favourites">Remove from Favourites</button>
     </div>
 
-    <div id="realtime_buses">
+    <div id="realtime_buses" role="real time" aria-label="real time schedule for stop">
         
     </div>
 
     <div class="d-grid gap-2">
-      <button id="back-to-stops" class="btn btn-primary" type="submit" style="display: none;" onclick="goToStopsPage()">Back to Stops</button>
+      <button
+        id="back-to-stops"
+        class="btn btn-primary"
+        type="submit"
+        style="display: none;"
+        aria-label="go back to search another stop"
+        onclick="goToStopsPage()">Back to Stops</button>
     </div>
 
   </div>

--- a/dublinbus/main/templates/main/routes.html
+++ b/dublinbus/main/templates/main/routes.html
@@ -19,34 +19,35 @@
 
     <p class="font-weight-bold text-center" id="route-header">Search by Route</p>
 
-    <div id="searchRouteUI">
+    <div id="searchRouteUI" role="search" aria-label="search for a bus route">
       
 
       <div class="form-group">
         <p class="text-center" id="user-error-message"></p>
         <div id="autocomplete" class="autocomplete">
-          <input class="autocomplete-input form-control" type="text" id="bus-route-input" placeholder="Bus Route"/>
+          <input class="autocomplete-input form-control" type="text" id="bus-route-input" placeholder="Bus Route" aria-label="bus route"/>
           <ul class="autocomplete-result-list"></ul>
         </div>
       </div>
 
       <div class="d-grid gap-2">
-          <button id="submit" class="btn btn-primary" type="submit" onclick="getBusStopsFromBackend()">Submit</button>
+          <button id="submit" class="btn btn-primary" type="submit" aria-label="submit bus route" onclick="getBusStopsFromBackend()">Submit</button>
       </div>
     </div>
 
-    <div id = "favourites">
+    <div id="favourites" aria-label="favourite routes">
       
     </div>
     
     <div id="directions-buttons" style="display: none;">
-      <ul class="nav nav-tabs mb-3" id="directions-tab" role="tablist">
+      <ul class="nav nav-tabs mb-3" id="directions-tab" role="tablist" aria-label="select bus direction">
         <li class="nav-item" role="presentation">
           <button
             class="nav-link active"
             id="direction-button-0"
             type="button"
             role="tab"
+            aria-label="change bus direction"
             aria-controls="direction-0"
             aria-selected="true"
             onclick="changeDirection(0)"
@@ -58,6 +59,7 @@
             id="direction-button-1"
             type="button"
             role="tab"
+            aria-label="change bus direction"
             aria-controls="direction-1"
             aria-selected="false"
             onclick="changeDirection(1)"
@@ -66,9 +68,25 @@
     </div>
 
     <div class="d-grid gap-2">
-      <button id="add-to-favourites" class="btn btn-primary" type="button" onclick="addToLocalstorage()">Add to Favourites</button>
-      <button id="remove-from-favourites" class="btn btn-primary" type="button">Remove from Favourites</button>
-      <button id="back-to-routes" class="btn btn-primary" type="submit" onclick="goToRoutesPage()">Back to Routes</button>
+      <button
+        id="add-to-favourites"
+        class="btn btn-primary"
+        type="button"
+        aria-label="add bus route to favourites"
+        onclick="addToLocalstorage()">Add to Favourites</button>
+
+      <button 
+        id="remove-from-favourites" 
+        class="btn btn-primary"
+        type="button"
+        aria-label="remove bus route from favourites">Remove from Favourites</button>
+
+      <button
+        id="back-to-routes"
+        class="btn btn-primary"
+        type="submit"
+        aria-label="go back to search for another route"
+        onclick="goToRoutesPage()">Back to Routes</button>
     </div>
 
   </div>    


### PR DESCRIPTION
## Context

This PR adds aria labels and alternative text to HTML elements. Please let me know something you think should be changed as I followed the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) and [W3](https://www.w3.org/WAI/GL/wiki/Using_aria-label_to_provide_labels_for_objects) guides but was the first time I did it and may have misunderstood or forgotten something important.

#### Note
I tried to add `tabindex` to fix the tab navigation with keyboard and although I was able to figure how to add this attribute to the Google HTML injected elements I then faced a few challenges when trying to make the tab select one route as we do with mouse click. Since this would take some time to figure out how to do I decided to just add the aria labels. In the future, however, this is something that would be feasible with a bit more time I think. 😃 