### PR TITLE
Fix one time only dot plot request to backend

### DIFF
--- a/dublinbus/main/static/journeyplanner.js
+++ b/dublinbus/main/static/journeyplanner.js
@@ -27,6 +27,9 @@ let travelTimeEstimations;
 let suggestedRoutesElements;
 let timeEstimationReplaced = false;
 
+// boolean used to prevent the dot plot to be requested to the backend more than once
+let isPlotBeingRequested = false;
+
 function initDirectionsService() {
   directionsService1 = new google.maps.DirectionsService();
 }
@@ -761,7 +764,8 @@ function QDP_request(lineid, prediction) {
     "&prediction=" +
     prediction;
   plotDiv = document.getElementById("plot");
-  if (!plotDiv) {
+  if (!plotDiv && !isPlotBeingRequested) {
+    isPlotBeingRequested = true;
     //Fetch request to backend
     fetch(endpoint)
       .then((response) => response.json())
@@ -769,6 +773,7 @@ function QDP_request(lineid, prediction) {
         //base64 will hold the bytestream which contains the image data.
         base64 = data["image_base64"];
         displayDotPlot(base64);
+        isPlotBeingRequested = false;
       })
       .catch((error) => {
         console.log(error);


### PR DESCRIPTION
## Context

This PR fixes a bug where previously if the user would click the "Show plot" button more than once before anything was displaying it would make multiple requests to the backend to generate the plot.

With this fix, this no longer happens and only one request is made to the backend regardless of the user clicking the button one or more times.
My approach was just to use a boolean global variable to store if one request was already made or not.