### PR TITLE
Realtime CSS fix for results window

### DIFF
--- a/dublinbus/main/static/style.css
+++ b/dublinbus/main/static/style.css
@@ -156,7 +156,7 @@ input {
 #realtime_buses,
 #directions_results {
   overflow: auto;
-  max-height: 60vh;
+  max-height: 45vh;
 }
 
 /* apply bold only to td elements in realtime page */


### PR DESCRIPTION
### Tiny PR

All this does is fix a small CSS display issue where sometimes the realtime busses would go down too far in the page on small devices. Before this PR, the results window for all the buses would sometimes overlay the location button and extend beyond the map.